### PR TITLE
Update NuGet release workflow and project metadata

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -7,9 +7,10 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
-
+    
 env:
-    LIB_CSPROJ: src/PJ.Gestures.Maui/PJ.Gestures.Maui.csproj
+    LIB_CSPROJ: PJ.Gesture.Maui/PJ.Gesture.Maui.csproj
+    PACKAGE_NAME: PJSouzaSoftware.Gesture.Maui
 
 jobs:
   release-nuget:
@@ -26,10 +27,11 @@ jobs:
       id: get_version
       uses: battila7/get-version-action@v2
     - name: Pack
-      run: dotnet pack ${{env.LIB_CSPROJ}} -c Release -p:PackageVersion=${{steps.get_version.outputs.version-without-v}} -o .output --include-symbols --include-source
+      run: dotnet pack ${{env.LIB_CSPROJ}} -c Release -p:PackageVersion=${{steps.get_version.outputs.version-without-v}} --output . --include-symbols --include-source
     - name: Publish
       env:
         API_KEY: ${{secrets.NUGET_KEY}}
       run: |
-        dotnet nuget push .output/*.nupkg --api-key $API_KEY --source https://api.nuget.org/v3/index.json
-        dotnet nuget push .output/*.snupkg --api-key $API_KEY --source https://symbols.nuget.org/
+        dotnet nuget push ${{env.PACKAGE_NAME}}.${{ steps.get_version.outputs.version-without-v }}.nupkg --api-key ${{secrets.NUGET_KEY}} --source https://api.nuget.org/v3/index.json
+        dotnet nuget push ${{env.PACKAGE_NAME}}.${{ steps.get_version.outputs.version-without-v }}.snupkg --api-key ${{secrets.NUGET_KEY}} --source https://symbols.nuget.org/
+

--- a/src/PJ.Gestures.Maui/PJ.Gestures.Maui.csproj
+++ b/src/PJ.Gestures.Maui/PJ.Gestures.Maui.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<Authors>Pedro Jesus</Authors>
 		<Company>PJSouzaSoftware</Company>
-		<Description>This project allows devs to implement and handle rich gesture on .NET MAUI</Description>
+		<Description>This project allows devs to implement and handle rich gestures on .NET MAUI</Description>
 
 		<PackageTags>.NET MAUI, GestureRecognizer, Gestures</PackageTags>
 		<PackageId>PJSouzaSoftware.Gestures.Maui</PackageId>

--- a/src/PJ.Gestures.Maui/PJ.Gestures.Maui.csproj
+++ b/src/PJ.Gestures.Maui/PJ.Gestures.Maui.csproj
@@ -1,1 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Authors>Pedro Jesus</Authors>
+		<Company>PJSouzaSoftware</Company>
+		<Description>This project allows devs to implement and handle rich gesture on .NET MAUI</Description>
+
+		<PackageTags>.NET MAUI, GestureRecognizer, Gestures</PackageTags>
+		<PackageId>PJSouzaSoftware.Gestures.Maui</PackageId>
+
+		<!--<PackageReadmeFile>README.md</PackageReadmeFile>-->
+		<RepositoryUrl>https://github.com/pictos/PJ.Gestures.Maui</RepositoryUrl>
+		<PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
+		<Product>Gestures.Maui</Product>
+		<Copyright>Copyright(c) 2025 Pedro Jesus</Copyright>
+
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
+
+
+</Project>


### PR DESCRIPTION
Update NuGet release workflow and project metadata

- Changed project file path in `release-nuget.yml`.
- Modified packing command to use `--output .`.
- Updated publish commands to reflect new package naming.
- Added metadata in `PJ.Gestures.Maui.csproj` including authors, company, description, and package settings.
- Configured project to embed untracked sources and include symbols in the package.